### PR TITLE
Updated example to use @metrics/client

### DIFF
--- a/example/client.js
+++ b/example/client.js
@@ -1,27 +1,20 @@
 'use strict';
 
-const stream = require('readable-stream');
+const Client = require('@metrics/client');
 const Emitter = require('../');
 
-const src = new stream.Readable({
-    objectMode: true,
-    read() {
-        // do nothing here
-    },
-});
-
 const emitter = new Emitter('udp');
-src.pipe(emitter);
+const client = new Client();
+
+client.pipe(emitter);
 
 let counter = 0;
 setInterval(() => {
-    const msg = {
+    client.metric({
         name: 'foo',
         description: 'bar',
         value: counter,
-        timestamp: Date.now() / 1000,
-    };
-    src.push(msg);
+    });
 
     counter += 1;
 }, 1000);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "readable-stream": "^3.1.1"
   },
   "devDependencies": {
+    "@metrics/client": "^2.2.0",
     "eslint": "^5.10.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.14.0",


### PR DESCRIPTION
Example does now use `@metrics/client` to create a metric stream.